### PR TITLE
[#9] Fixing bugs from previous sprint

### DIFF
--- a/SpendWise/SpendWise/ViewModel/ExpenseViewModel.swift
+++ b/SpendWise/SpendWise/ViewModel/ExpenseViewModel.swift
@@ -80,9 +80,11 @@ final class ExpenseViewModel: ObservableObject {
         return groupedTransactions
     }
     
+    func checkNumber(isNumber: String) -> Bool{
+        return !isNumber.isEmpty && Double(isNumber) != nil
+    }
+    
     func editExpense(expense: Expense, id: Int){
-
-        
         store.expenses = store.expenses.map{ exp in
             var modifiedExpenses = exp
             

--- a/SpendWise/SpendWise/Views/EditExpense.swift
+++ b/SpendWise/SpendWise/Views/EditExpense.swift
@@ -210,10 +210,8 @@ struct EditExpense: View {
                         animateCategory.toggle()
                         valid = false
                     }
-                    
-                    
                     var doubleAmount = 0.0
-                    if(amount != "") {
+                    if(amount != "" && expenseViewModel.checkNumber(isNumber: String(amount))) {
                         if let dAmount = Double(amount) {
                             doubleAmount = dAmount
                         } else {
@@ -264,8 +262,6 @@ struct EditExpense: View {
                     
                     expenseViewModel.editExpense(expense: newExpense, id: expense.id)
                     
-//                    print("Edir=t variable")
-//                    print(expenseViewModel.store.expenses)
                     
                     dismiss()
                 })


### PR DESCRIPTION
Fixed the edit expense sheet bug to throw an error if the user enters a string where its meant to be an integer

close #9